### PR TITLE
Councilmatic update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2==2.6.2
-https://github.com/datamade/django-councilmatic/zipball/master
+django-councilmatic==0.8.3
 django-councilmatic-notifications<0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2==2.6.2
-django-councilmatic==0.8.1
+https://github.com/datamade/django-councilmatic/zipball/master
 django-councilmatic-notifications<0.2


### PR DESCRIPTION
@hancush - the upgrade to the newest Councilmatic did not require any application-side adjustments. I am pinning it to version 0.8.3, but if we find ourselves revising Councilmatic, as we revise NYC then we might pin it to master. 