### PR TITLE
Add flock to cron

### DIFF
--- a/scripts/nyc-council-councilmatic-crontasks
+++ b/scripts/nyc-council-councilmatic-crontasks
@@ -1,3 +1,3 @@
 # /etc/cron.d/nyc-council-councilmatic-crontasks
-10,25,40,55 * * * * datamade /usr/bin/flock /tmp/nyc_dataload.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1'
-10,25,40,55 * * * * datamade /usr/bin/flock /tmp/nyc_updateindex.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index'
+10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1'
+10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_updateindex.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index'

--- a/scripts/nyc-council-councilmatic-crontasks
+++ b/scripts/nyc-council-councilmatic-crontasks
@@ -1,3 +1,3 @@
 # /etc/cron.d/nyc-council-councilmatic-crontasks
-10,25,40,55 * * * * datamade cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1
-10,25,40,55 * * * * datamade cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index
+10,25,40,55 * * * * datamade /usr/bin/flock /tmp/nyc_dataload.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1'
+10,25,40,55 * * * * datamade /usr/bin/flock /tmp/nyc_updateindex.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index'


### PR DESCRIPTION
This PR ensures that data import jobs do not overlap if a job takes longer than 15 minutes.