### PR TITLE
Last action date

### DIFF
--- a/nyc/search_indexes.py
+++ b/nyc/search_indexes.py
@@ -31,11 +31,12 @@ class NYCBillIndex(BillIndex, indexes.Indexable):
 
             if index_actions:
                 # Newer versions of Solr seem to be fussy about the time format, and we do not need the time, just the date stamp.
+                # https://lucene.apache.org/solr/guide/7_1/working-with-dates.html#date-formatting
                 index_actions = max(index_actions).date()
 
             return index_actions
 
-        return obj.last_action_date
+        return obj.last_action_date.date()
 
     def prepare_bill_type(self, obj):
         return obj.bill_type

--- a/scripts/nyc-council-councilmatic-crontasks
+++ b/scripts/nyc-council-councilmatic-crontasks
@@ -1,3 +1,2 @@
 # /etc/cron.d/nyc-council-councilmatic-crontasks
 10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1'
-10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_updateindex.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index --batch-size=200'

--- a/scripts/nyc-council-councilmatic-crontasks
+++ b/scripts/nyc-council-councilmatic-crontasks
@@ -1,3 +1,3 @@
 # /etc/cron.d/nyc-council-councilmatic-crontasks
 10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1'
-10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_updateindex.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index'
+10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_updateindex.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index --batch-size=200'


### PR DESCRIPTION
This PR formats the last_action_date for haystack and removes the crontask for updating index after import, since [the import script runs this command if using notifications](https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/import_data.py#L155).

Related to https://github.com/datamade/django-councilmatic/pull/164