### PR TITLE
Default links to Search page should sort by relevance

### DIFF
--- a/nyc/views.py
+++ b/nyc/views.py
@@ -208,6 +208,7 @@ class NYCCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
         if form_kwargs:
             kwargs.update(form_kwargs)
 
+        dataDict = {}
         if len(self.request.GET):
             data = self.request.GET
             dataDict = dict(data)
@@ -215,25 +216,25 @@ class NYCCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
         if self.searchqueryset is not None:
             kwargs['searchqueryset'] = sqs
 
-            try:
+            if dataDict.get('sort_by'):
                 for el in dataDict['sort_by']:
                     # Do this, because sometimes the 'el' may include a '?' from the URL
                     if 'date' in el:
-                        try:
-                            dataDict['ascending']
+                        if dataDict.get('ascending'):
                             kwargs['searchqueryset'] = sqs.order_by('last_action_date')
-                        except:
+                        else:
                             kwargs['searchqueryset'] = sqs.order_by('-last_action_date')
                     if 'title' in el:
-                        try:
-                            dataDict['descending']
+                        if dataDict.get('descending'):
                             kwargs['searchqueryset'] = sqs.order_by('-sort_name')
-                        except:
+                        else:
                             kwargs['searchqueryset'] = sqs.order_by('sort_name')
                     if 'relevance' in el:
                         kwargs['searchqueryset'] = sqs
 
-            except:
+            elif dataDict.get('q'):
+                kwargs['searchqueryset'] = sqs
+            else:
                 kwargs['searchqueryset'] = sqs.order_by('-last_action_date')
 
         return self.form_class(data, **kwargs)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,8 +6,6 @@ from django.test import TestCase, Client
 from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator
 
-from nyc.models import NYCBill
-from nyc.views import NYCCouncilmaticFacetedSearchView
 
 # Different combinations of possible parameters
 sorters = ['title', 'date', 'relevance', None]
@@ -28,7 +26,7 @@ def test_search_params(sort_by, ascending, query, mocker):
         if ascending:
             query_string += '&ascending={ascending}'.format(ascending=ascending)
         if query:
-            query_string += '%q={query}'.format(query=query)
+            query_string += '&q={query}'.format(query=query)
     else:
         query_string = ''
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock
+
+import pytest
+from haystack.query import SearchQuerySet
+from django.test import TestCase, Client
+from django.core.urlresolvers import reverse
+from django.core.paginator import Paginator
+
+from nyc.models import NYCBill
+from nyc.views import NYCCouncilmaticFacetedSearchView
+
+# Different combinations of possible parameters
+sorters = ['title', 'date', 'relevance', None]
+ascenders = ['true', None]
+queries = ['test', None]
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('sort_by', sorters)
+@pytest.mark.parametrize('ascending', ascenders)
+@pytest.mark.parametrize('query', queries)
+def test_search_params(sort_by, ascending, query, mocker):
+
+    # Use different query strings depending on the params
+    if sort_by or ascending or query:
+        query_string = '?'
+        if sort_by:
+            query_string += 'sort_by={sort_by}'.format(sort_by=sort_by)
+        if ascending:
+            query_string += '&ascending={ascending}'.format(ascending=ascending)
+        if query:
+            query_string += '%q={query}'.format(query=query)
+    else:
+        query_string = ''
+
+    # Mock the SearchQuerySet.order_by method so we can track how it's used
+    sqs = MagicMock(spec=SearchQuerySet)
+    empty_qs = sqs
+    order_func = sqs.facet().facet().facet().facet().facet().highlight().order_by
+    order_func.return_value = empty_qs
+    mocker.patch('nyc.views.SearchQuerySet', return_value=sqs)
+
+    # Also mock out the `extra_context` method of the search view, which
+    # will try to check to make sure Solr is running otherwise
+    mocker.patch('nyc.views.NYCCouncilmaticFacetedSearchView.extra_context', return_value={})
+
+    # The Paginator object gets mad if Solr doesn't return any actual results,
+    # so let's mock it out too
+    pag = MagicMock(spec=Paginator)
+    pag.validate_number.return_value = 0
+    mocker.patch('haystack.views.Paginator', return_value=pag)
+
+    client = Client()
+    search = client.get(reverse('search') + query_string)
+
+    assert search.status_code == 200
+
+    if sort_by and sort_by != 'relevance':
+
+        # Make sure ordering was applied
+        assert order_func.call_count == 1
+
+        # Look for the emphasized button on the page signalling that this
+        # ordering key has been selected
+        button= '<strong>{sort_by}</strong>'.format(sort_by=sort_by.title())
+        assert button in search.content.decode('utf-8')
+
+    elif query or sort_by == 'relevance':
+        # When a query exists with no sort_by value, we default
+        # to ordering by `relevance` (hence `SearchQuerySet.order_by` will
+        # not get called)
+        order_func.assert_not_called()
+    else:
+        # When no query or sort_by values exist, we default to `date` ordering
+        assert order_func.call_count == 1
+        assert order_func.called_with('-last_action_date')
+
+    # Check that the ascending keyword got handled
+    if sort_by and sort_by != 'relevance': # Relevance doesn't display anything for ascending
+        if ascending:
+            assert 'fa-sort-amount-asc' in search.content.decode('utf-8')
+        else:
+            if sort_by == 'date':
+                # Descending is the default for Date
+                assert 'fa-sort-amount-desc' in search.content.decode('utf-8')
+            elif sort_by == 'title':
+                # Ascending is the default for Title
+                assert 'fa-sort-amount-asc' in search.content.decode('utf-8')


### PR DESCRIPTION
Some of the default searches we recommend (like "Resolution 815-2015") don't actually show the right results, since we don't automatically sort by relevance. This PR changes links to the Search page such that the default mode is to search by relevance.

Closes #88.