### PR TITLE
Use controlling body for tags

### DIFF
--- a/nyc/templates/partials/tags.html
+++ b/nyc/templates/partials/tags.html
@@ -1,0 +1,32 @@
+{% load extras %}
+
+{% if result.last_action_date %}
+    <p class="small text-muted condensed">
+        <i class="fa fa-fw fa-calendar-o"></i> {{result.last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }}
+    </p>
+{% elif result.object.get_last_action_date %}
+     <p class="small text-muted condensed">
+        <i class="fa fa-fw fa-calendar-o"></i> {{result.object.get_last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }}
+    </p>
+{% endif %}
+
+{% if result.object.primary_sponsor %}
+    <p class="small text-muted condensed">
+        <i class="fa fa-fw fa-user"></i>
+        {{result.object.primary_sponsor.person.name}}
+    </p>
+{% endif %}
+
+<div class="row">
+    <div class="col-xs-11">
+    {% if result.object.controlling_body %}
+        <i class="fa fa-fw fa-tag"></i>
+        {% for tag in result.object.controlling_body %}
+            <span class="badge badge-muted pseudo-topic-tag">
+                <a href='/search/?selected_facets=controlling_body_exact:{{ tag }}'>{{ tag | committee_topic_only }}</a>
+            </span>
+        {% endfor %}
+    {% endif %}
+    <br/><br/>
+    </div>
+</div>


### PR DESCRIPTION
This PR overrides the [tags template in django-councilmatic](https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/templates/partials/tags.html). It generates tags with the controlling body, rather than topics (for which we do not have custom logic). 

Handles issue #123  

(Related to issue #121)