### PR TITLE
Remove limit to the number of sponsor facets

### DIFF
--- a/nyc/views.py
+++ b/nyc/views.py
@@ -199,7 +199,7 @@ class NYCCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
         }
 
         sqs = SearchQuerySet().facet('bill_type')\
-                      .facet('sponsorships', sort='index')\
+                      .facet('sponsorships', sort='index', limit=-1)\
                       .facet('controlling_body')\
                       .facet('inferred_status')\
                       .facet('legislative_session', sort='index')\


### PR DESCRIPTION
Turns out Haystack adds [an implicit limit of 100](http://django-haystack.readthedocs.io/en/master/faceting.html?highlight=limit#configuring-facet-behaviour) to the facets that it returns. Because of this limit, we were missing some council members (of which there are 160) in our facets (#105). 

No test for this one, since it's a setting internal to Solr and I don't want to require that as a test dependency.