### PR TITLE
Run scripts every 20 minutes

### DIFF
--- a/scripts/nyc-council-councilmatic-crontasks
+++ b/scripts/nyc-council-councilmatic-crontasks
@@ -1,4 +1,4 @@
 # /etc/cron.d/nyc-council-councilmatic-crontasks
 APPDIR=/home/datamade/nyc-council-councilmatic
 PYTHONDIR=/home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python
-0 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=50 --age=1 >> /tmp/nyc_updateindex.log 2>&1 && $PYTHONDIR manage.py convert_rtf >> /tmp/nyc_convert_rtf.log 2>&1 && $PYTHONDIR manage.py send_notifications >> /tmp/nyc_sendnotifications.log 2>&1'
+5,25,45 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=50 --age=1 >> /tmp/nyc_updateindex.log 2>&1 && $PYTHONDIR manage.py convert_rtf >> /tmp/nyc_convert_rtf.log 2>&1 && $PYTHONDIR manage.py send_notifications >> /tmp/nyc_sendnotifications.log 2>&1'


### PR DESCRIPTION
@jeancochrane - I set the cron to run every hour for a period, since implementing [this change](https://github.com/datamade/django-councilmatic/pull/169). Given the logs, it appears we can safely run the cron every 20 minutes. Let's include this change in our upcoming deployment.