### PR TITLE
Turn off cron

### DIFF
--- a/scripts/nyc-council-councilmatic-crontasks
+++ b/scripts/nyc-council-councilmatic-crontasks
@@ -1,4 +1,4 @@
 # /etc/cron.d/nyc-council-councilmatic-crontasks
 APPDIR=/home/datamade/nyc-council-councilmatic
 PYTHONDIR=/home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python
-5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py import_data >> /var/log/councilmatic/nyc-council-councilmatic-importdata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=100 --age=1 >> /var/log/councilmatic/nyc-updateindex.log 2>&1 && $PYTHONDIR manage.py convert_rtf >> /var/log/councilmatic/nyc-convertrtf.log 2>&1 && $PYTHONDIR manage.py send_notifications >> /var/log/councilmatic/nyc-sendnotifications.log 2>&1'
+# 5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py import_data >> /var/log/councilmatic/nyc-council-councilmatic-importdata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=100 --age=1 >> /var/log/councilmatic/nyc-updateindex.log 2>&1 && $PYTHONDIR manage.py convert_rtf >> /var/log/councilmatic/nyc-convertrtf.log 2>&1 && $PYTHONDIR manage.py send_notifications >> /var/log/councilmatic/nyc-sendnotifications.log 2>&1'

--- a/scripts/nyc-council-councilmatic-staging-crontasks
+++ b/scripts/nyc-council-councilmatic-staging-crontasks
@@ -1,4 +1,4 @@
 # /etc/cron.d/nyc-council-councilmatic-staging-crontasks
 APPDIR=/home/datamade/nyc-council-councilmatic
 PYTHONDIR=/home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python
-0 0 * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=50 --age=24 >> /tmp/nyc_updateindex.log 2>&1 && $PYTHONDIR manage.py convert_rtf >> /tmp/nyc_convert_rtf.log 2>&1 && $PYTHONDIR manage.py send_notifications >> /tmp/nyc_sendnotifications.log 2>&1'
+# 0 0 * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=50 --age=24 >> /tmp/nyc_updateindex.log 2>&1 && $PYTHONDIR manage.py convert_rtf >> /tmp/nyc_convert_rtf.log 2>&1 && $PYTHONDIR manage.py send_notifications >> /tmp/nyc_sendnotifications.log 2>&1'


### PR DESCRIPTION
This PR turns off cron in preparation for running migrations agains the Councilmatic database. Relates to: https://github.com/datamade/scrapers-us-municipal/issues/12